### PR TITLE
Fixes for compilation on Linux with a modern toolchain

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -85,8 +85,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR (CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT CMAKE
 
 	add_compile_options(-pipe)
 	#add_compile_options(-Wall)
-	add_compile_options(-Werror=format-security)
-	add_compile_options(-Werror=format)
+	add_compile_options(-Wno-error=format-security)
+	add_compile_options(-Wno-error=format)
 	add_compile_options(-Wno-format-zero-length)
 	add_compile_options(-Wno-nonnull)
 

--- a/neo/idlib/Lib.cpp
+++ b/neo/idlib/Lib.cpp
@@ -314,7 +314,7 @@ void idLib::PrintCallStack()
 	char message[4096];
 	idDebugSystem::StringifyStack( hash, callstack.Ptr(), callstack.Num(), message, sizeof( message ) );
 
-	Printf( message );
+	Printf( "%s", message );
 }
 
 /*

--- a/neo/idlib/containers/List.h
+++ b/neo/idlib/containers/List.h
@@ -96,8 +96,8 @@ ID_INLINE void* idListArrayResize( void* voldptr, int oldNum, int newNum, bool z
 		int overlap = Min( oldNum, newNum );
 		for( int i = 0; i < overlap; i++ )
 		{
-			//newptr[i] = oldptr[i];
-			newptr[i] = std::move( oldptr[i] );
+			newptr[i] = oldptr[i];
+			//newptr[i] = std::move( oldptr[i] );
 		}
 	}
 	idListArrayDelete<_type_>( voldptr, oldNum );

--- a/neo/idlib/sys/posix/posix_crashhandler.cpp
+++ b/neo/idlib/sys/posix/posix_crashhandler.cpp
@@ -29,9 +29,9 @@ If you have questions concerning this license or the applicable additional terms
 #include "precompiled.h"
 #pragma hdrstop
 
-uint8 g_crashStackData[4096];
-int g_crashStackLen = 0;
-uint32 g_crashStackHash = 0;
+extern uint8 g_crashStackData[4096];
+extern int g_crashStackLen;
+extern uint32 g_crashStackHash;
 
 /*
 ====================

--- a/neo/idlib/sys/posix/posix_signal.cpp
+++ b/neo/idlib/sys/posix/posix_signal.cpp
@@ -156,7 +156,7 @@ void Sys_InitSigs()
 	{
 		if( siglist[ i ] == SIGFPE )
 		{
-			action.sa_sigaction = Sys_FPE_handler;
+			action.sa_sigaction = sig_handler;
 			if( sigaction( siglist[ i ], &action, NULL ) != 0 )
 			{
 				idLib::Printf( "Failed to set SIGFPE handler: %s\n", strerror( errno ) );

--- a/neo/idlib/sys/sys_assert.h
+++ b/neo/idlib/sys/sys_assert.h
@@ -110,14 +110,14 @@ template<int x> struct compile_time_assert_test {};
 #define compile_time_assert_join( a, b )	compile_time_assert_join2(a,b)
 #define compile_time_assert( x )			typedef compile_time_assert_test<sizeof(compile_time_assert_failed<(bool)(x)>)> compile_time_assert_join(compile_time_assert_typedef_, __LINE__)
 
+#endif
+
 #define assert_sizeof( type, size )						compile_time_assert( sizeof( type ) == size )
 #define assert_sizeof_8_byte_multiple( type )			compile_time_assert( ( sizeof( type ) &  7 ) == 0 )
 #define assert_sizeof_16_byte_multiple( type )			compile_time_assert( ( sizeof( type ) & 15 ) == 0 )
 #define assert_offsetof( type, field, offset )			compile_time_assert( offsetof( type, field ) == offset )
 #define assert_offsetof_8_byte_multiple( type, field )	compile_time_assert( ( offsetof( type, field ) & 7 ) == 0 )
 #define assert_offsetof_16_byte_multiple( type, field )	compile_time_assert( ( offsetof( type, field ) & 15 ) == 0 )
-
-#endif
 
 #else
 

--- a/neo/sys/posix/posix_seh.cpp
+++ b/neo/sys/posix/posix_seh.cpp
@@ -130,7 +130,7 @@ void Sys_ShowCrashDialog( const char* summaryText )
 		ImGui::Render();
 		SDL_SetRenderDrawColor( ren, 24, 24, 24, 255 );
 		SDL_RenderClear( ren );
-		ImGui_ImplSDLRenderer2_RenderDrawData( ImGui::GetDrawData() );
+		ImGui_ImplSDLRenderer2_RenderDrawData( ImGui::GetDrawData(), ren );
 		SDL_RenderPresent( ren );
 		SDL_Delay( 16 );
 	}

--- a/neo/sys/sdl/DeviceShared.cpp
+++ b/neo/sys/sdl/DeviceShared.cpp
@@ -58,7 +58,7 @@ unsigned int Sys_Milliseconds()
 Sys_Microseconds
 ========================
 */
-uint64_t Sys_Microseconds()
+uint64 Sys_Microseconds()
 {
 	static uint64_t frequency = SDL_GetPerformanceFrequency();
 	uint64_t counter = SDL_GetPerformanceCounter();

--- a/neo/tools/compilers/compiler_thread.cpp
+++ b/neo/tools/compilers/compiler_thread.cpp
@@ -205,6 +205,7 @@ static void RoQFileEncode_Threaded_f( const idCmdArgs& args )
 Amplitude_Threaded_f
 ========================
 */
+
 static void Amplitude_Threaded_f( const idCmdArgs& args )
 {
 	if( g_compilerThread.IsRunning() )
@@ -214,7 +215,6 @@ static void Amplitude_Threaded_f( const idCmdArgs& args )
 	}
 	g_compilerThread.Dispatch( Amplitude_f, args, "AmplitudeThread" );
 }
-
 /*
 ========================
 Compiler_Wait_f

--- a/neo/tools/imgui/lighteditor/LightEditor.cpp
+++ b/neo/tools/imgui/lighteditor/LightEditor.cpp
@@ -303,7 +303,7 @@ void LightEditor::Init( const idDict* dict, idEntity* light )
 		gameEdit->EntityGetOrigin( light, entityPos );
 
 		idStr name = dict->GetString( "name", NULL );
-		entityName = name ? name :  gameEdit->GetUniqueEntityName( "light" );
+		entityName = name.Length() ? name.c_str() :  gameEdit->GetUniqueEntityName( "light" );
 		name.Format( "Light Editor: %s at (%s)###LightEditor", entityName.c_str(), entityPos.ToString() );
 		title = name;
 


### PR DESCRIPTION
got to the point of producing a binary on Linux (with renderer issues currently)

this is everything up to the point of local changes omitting amplitude (wav in map compiler) since idk what direction you're taking things with this engine; 

to compile I commented out everything to do with amplitude in neo/CMakeLists.txt, neo/tools/compilers/compiler_thread.cpp